### PR TITLE
feat: Add http security headers

### DIFF
--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -23,6 +23,43 @@ data "aws_acm_certificate" "wildcard" {
   provider = aws.us-east-1
 }
 
+# HTTP security headers
+resource "aws_cloudfront_response_headers_policy" "diagram" {
+  name = "security-headers"
+
+  custom_headers_config {
+    items {
+      header   = "X-Permitted-Cross-Domain-Policies"
+      override = true
+      value    = "none"
+    }
+
+    items {
+      header   = "Cache-Control"
+      override = true
+      value    = "no-cache"
+    }
+  }
+
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+
+    frame_options {
+      override     = true
+      frame_option = "SAMEORIGIN"
+    }
+
+    strict_transport_security {
+      override                   = true
+      access_control_max_age_sec = 31536000
+    }
+  }
+
+}
+
+
 # Create CloudFront distribution
 resource "aws_cloudfront_distribution" "diagram" {
   aliases = ["${var.service[local.workspace].url}"]
@@ -34,9 +71,9 @@ resource "aws_cloudfront_distribution" "diagram" {
     origin_id   = "${local.project_ns}-site"
 
     custom_origin_config {
-      http_port                = 80
-      https_port               = 443
-      origin_protocol_policy   = "http-only"
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
       origin_ssl_protocols = [
         "TLSv1.2",
       ]
@@ -83,12 +120,13 @@ resource "aws_cloudfront_distribution" "diagram" {
         forward = "all"
       }
     }
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.diagram.id
   }
 
   # Forward requsts of /api/ to API Gateway
   ordered_cache_behavior {
     path_pattern           = "/api/*"
-    target_origin_id   = "${local.project_ns}-api_gw"
+    target_origin_id       = "${local.project_ns}-api_gw"
     viewer_protocol_policy = "allow-all"
     # Allow all standard verbs
     allowed_methods = [

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -57,7 +57,7 @@ resource "aws_cloudfront_response_headers_policy" "diagram" {
     }
 
     content_security_policy {
-      content_security_policy = "default-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'sha256-kFAIUwypIt04FgLyVU63Lcmp2AQimPh/TdYjy04Flxs=' https://fonts.googleapis.com 'unsafe-hashes' 'sha256-2AMfKUIQeL5s2LTyEqbLB08wir4HW4qmUF8KGwRrHpU=' 'sha256-D/q/6FIu6/KApfXCg8WR5j4bB61MmNj2trZtp744lJs=' ; img-src 'self' blob:;"
+      content_security_policy = "default-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'sha256-kFAIUwypIt04FgLyVU63Lcmp2AQimPh/TdYjy04Flxs=' https://fonts.googleapis.com 'unsafe-hashes' 'sha256-2AMfKUIQeL5s2LTyEqbLB08wir4HW4qmUF8KGwRrHpU=' 'sha256-D/q/6FIu6/KApfXCg8WR5j4bB61MmNj2trZtp744lJs='; img-src 'self' blob:;"
       override                = true
     }
   }

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -150,6 +150,7 @@ resource "aws_cloudfront_distribution" "diagram" {
         forward = "all"
       }
     }
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.diagram.id
   }
 
   restrictions {

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -57,7 +57,7 @@ resource "aws_cloudfront_response_headers_policy" "diagram" {
     }
 
     content_security_policy {
-      content_security_policy = "default-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'sha256-kFAIUwypIt04FgLyVU63Lcmp2AQimPh/TdYjy04Flxs=' https://fonts.googleapis.com 'unsafe-hashes' 'sha256-2AMfKUIQeL5s2LTyEqbLB08wir4HW4qmUF8KGwRrHpU=' 'sha256-D/q/6FIu6/KApfXCg8WR5j4bB61MmNj2trZtp744lJs='; img-src 'self' blob:;"
+      content_security_policy = "default-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' https://fonts.googleapis.com 'unsafe-hashes' 'sha256-kFAIUwypIt04FgLyVU63Lcmp2AQimPh/TdYjy04Flxs=' 'sha256-2AMfKUIQeL5s2LTyEqbLB08wir4HW4qmUF8KGwRrHpU=' 'sha256-D/q/6FIu6/KApfXCg8WR5j4bB61MmNj2trZtp744lJs='; img-src 'self' blob:;"
       override                = true
     }
   }

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -55,6 +55,11 @@ resource "aws_cloudfront_response_headers_policy" "diagram" {
       override                   = true
       access_control_max_age_sec = 31536000
     }
+
+    content_security_policy {
+      content_security_policy = "default-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'sha256-kFAIUwypIt04FgLyVU63Lcmp2AQimPh/TdYjy04Flxs=' https://fonts.googleapis.com 'unsafe-hashes' 'sha256-2AMfKUIQeL5s2LTyEqbLB08wir4HW4qmUF8KGwRrHpU=' 'sha256-D/q/6FIu6/KApfXCg8WR5j4bB61MmNj2trZtp744lJs=' ; img-src 'self' blob:;"
+      override                = true
+    }
   }
 
 }

--- a/components/website/variables.tf
+++ b/components/website/variables.tf
@@ -31,16 +31,16 @@ variable "service" {
   description = "Properties that vary between workspaces"
   default = {
     live = {
-      suffix  = ""
-      url     = "diagram.nationalarchives.gov.uk"
+      suffix = ""
+      url    = "diagram.nationalarchives.gov.uk"
     }
     stage = {
-      suffix  = "-staging"
-      url     = "staging-diagram.nationalarchives.gov.uk"
+      suffix = "-staging"
+      url    = "staging-diagram.nationalarchives.gov.uk"
     }
     dev = {
-      suffix  = "-dev"
-      url     = "dev-diagram.nationalarchives.gov.uk"
+      suffix = "-dev"
+      url    = "dev-diagram.nationalarchives.gov.uk"
     }
   }
 }


### PR DESCRIPTION
## About

The changes in this PR add HTTP headers to improve security from a clients point-of-view.

In particular, this PR adds the following headers:

- X-Content-Type-Options Sniffing
- Strict-Transport-Security (HSTS)
- Cache-control
- X-Frame-Options
- X-Permitted-Cross-Domain-Policies
- CSP (more on these below)

```sh
❯ curl -I https://diagram.nationalarchives.gov.uk/
HTTP/2 200
content-type: text/html
content-length: 34703
date: Wed, 08 Feb 2023 14:43:51 GMT
last-modified: Wed, 08 Feb 2023 10:11:44 GMT
server: AmazonS3
etag: "d688039c1d776d55b72a38514c7937a3"
x-cache: Miss from cloudfront
via: 1.1 0be31418aaf200eda938a2f593d7dcf8.cloudfront.net (CloudFront)
x-amz-cf-pop: MAN51-P1
x-amz-cf-id: XQIaC1RGfklu42IOcafzTQjMeUEuXL9B6PKyUqaPYE19kbDX-2yJOg==
x-frame-options: SAMEORIGIN
content-security-policy: default-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'sha256-kFAIUwypIt04FgLyVU63Lcmp2AQimPh/TdYjy04Flxs=' https://fonts.googleapis.com 'unsafe-hashes' 'sha256-2AMfKUIQeL5s2LTyEqbLB08wir4HW4qmUF8KGwRrHpU=' 'sha256-D/q/6FIu6/KApfXCg8WR5j4bB61MmNj2trZtp744lJs=' ; img-src 'self' blob:;
x-content-type-options: nosniff
strict-transport-security: max-age=31536000
cache-control: no-cache
x-permitted-cross-domain-policies: none
```

## CSP

The following policy has been set for CSP:
```
default-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'sha256-kFAIUwypIt04FgLyVU63Lcmp2AQimPh/TdYjy04Flxs=' https://fonts.googleapis.com 'unsafe-hashes' 'sha256-2AMfKUIQeL5s2LTyEqbLB08wir4HW4qmUF8KGwRrHpU=' 'sha256-D/q/6FIu6/KApfXCg8WR5j4bB61MmNj2trZtp744lJs=' ; img-src 'self' blob:;
```

Of particular interest may be the `style-src` directive, and the referenced hashes. This directive is allowing the [_inline inclusion_](https://content-security-policy.com/examples/allow-inline-style/) of style in three places:
- [`content/home.html`](https://github.com/nationalarchives/DiAGRAM/blob/live/app/frontend/content/home.html#L6)
- [`raw-img/DiAGRAM-Roboto.svg`](https://github.com/nationalarchives/DiAGRAM/blob/live/app/frontend/raw-img/DiAGRAM-Roboto.svg)
- [`www/diagram.svg`](https://github.com/nationalarchives/DiAGRAM/blob/live/app/frontend/www/diagram.svg)

Rather than allowing these inline styles, a better solution longer term would be to remove the reliance on inline styling.