### PR TITLE
feat(website): Add WAF to dev and stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ secrets = {
       account = "<DEV-ENV-ACCOUNT-ID>"
     }
   }
+  # Allowed IPs only required for website component
+  allowed_ips = []
 }
 ```
 
@@ -146,7 +148,9 @@ the application, from scratch, the following steps must be followed:
    container image pushed in the previous step, and API Gateway integration.
 
 6. Run `terraform apply -target module.tna_zones` and then `terraform apply`,
-   for each workspace in the [`website/`](/components/website/) module.
+   for each workspace in the [`website/`](/components/website/) module. Add any
+   IPs that need access to the dev and stage sites to the `secrets.auto.tfvars`
+   `allowed_ips` list.
 
 7. Trigger the CI job [`update-frontend`](https://github.com/nationalarchives/DiAGRAM/blob/live/.github/workflows/update-backend.yml)
    from each GitHub environment. This will build the static site frontend, and

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -193,13 +193,13 @@ resource "aws_wafv2_web_acl" "cloudfront" {
   custom_response_body {
     key = "access-denied"
     content = <<-EOT
-    <html>
-    <title>404 Not Found</title>
-    <h1>404 Not Found</h1>
-
-    <p>The requested resource was not found.</p>
-
-    </html>
+      <html><head>
+      <meta http-equiv="content-type" content="text/html; charset=windows-1252">
+      <title>404 Not Found</title>
+      </head><body>
+      <h1>Not Found</h1>
+      <p>The requested URL was not found on this server.</p>
+      </body></html>
     EOT
     content_type = "TEXT_HTML"
   }

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -64,12 +64,12 @@ resource "aws_cloudfront_response_headers_policy" "diagram" {
 
 }
 
-
 # Create CloudFront distribution
 resource "aws_cloudfront_distribution" "diagram" {
   aliases = ["${var.service[local.workspace].url}"]
   enabled = true
-
+  # WAF only added to dev and staging for IP restrictions
+  web_acl_id = local.has_waf ? aws_wafv2_web_acl.cloudfront[0].arn : null
   # Frontend origin (S3 bucket)
   origin {
     domain_name = aws_s3_bucket_website_configuration.website.website_endpoint
@@ -170,4 +170,59 @@ resource "aws_cloudfront_distribution" "diagram" {
     minimum_protocol_version = "TLSv1.2_2021"
     acm_certificate_arn      = data.aws_acm_certificate.wildcard.arn
   }
+}
+
+resource "aws_wafv2_ip_set" "allowed_ips" {
+  # Only create for dev and staging (now WAF on live)
+  count              = local.has_waf ? 1 : 0
+  name               = "allowed_ips"
+  description        = "IPs that can access the DiAGRAM frontend"
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV4"
+  addresses = []
+  # WAF must use us-east-1 region when scope is CLOUDFRONT
+  provider = aws.us-east-1
+}
+
+resource "aws_wafv2_web_acl" "cloudfront" {
+  # Only create for dev and staging (now WAF on live)
+  count = local.has_waf ? 1 : 0
+  name  = "cloudfront_acl"
+  scope = "CLOUDFRONT"
+
+  # Block access by default
+  default_action {
+    block {}
+  }
+
+  # Allow IPs access in IP whitelist
+  rule {
+    name     = "allow_allowed_ips"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.allowed_ips[count.index].arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-rule-metric-name"
+    sampled_requests_enabled   = false
+  }
+
+  # WAF must use us-east-1 region when scope is CLOUDFRONT
+  provider = aws.us-east-1
 }

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -194,11 +194,10 @@ resource "aws_wafv2_web_acl" "cloudfront" {
     key = "access-denied"
     content = <<-EOT
     <html>
-    <p>Sorry, you can&#39;t access this page!</p>
+    <title>404 Not Found</title>
+    <h1>404 Not Found</h1>
 
-    <p>Did you mean to visit our production site, <a href='https://diagram.nationalarchives.gov.uk'>https://diagram.nationalarchives.gov.uk</a> ?</p>
-
-    <p>If you&#39;re a DiAGRAM developer, you&#39;ll need to be connected to TNA&#39;s VPN to access the development and staging sites.</p>
+    <p>The requested resource was not found.</p>
 
     </html>
     EOT
@@ -210,7 +209,7 @@ resource "aws_wafv2_web_acl" "cloudfront" {
     block {
       custom_response {
         custom_response_body_key = "access-denied"
-        response_code = "403"
+        response_code = "404"
       }
     }
   }

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -190,9 +190,29 @@ resource "aws_wafv2_web_acl" "cloudfront" {
   name  = "cloudfront_acl"
   scope = "CLOUDFRONT"
 
+  custom_response_body {
+    key = "access-denied"
+    content = <<-EOT
+    <html>
+    <p>Sorry, you can&#39;t access this page!</p>
+
+    <p>Did you mean to visit our production site, <a href='https://diagram.nationalarchives.gov.uk'>https://diagram.nationalarchives.gov.uk</a> ?</p>
+
+    <p>If you&#39;re a DiAGRAM developer, you&#39;ll need to be connected to TNA&#39;s VPN to access the development and staging sites.</p>
+
+    </html>
+    EOT
+    content_type = "TEXT_HTML"
+  }
+
   # Block access by default
   default_action {
-    block {}
+    block {
+      custom_response {
+        custom_response_body_key = "access-denied"
+        response_code = "403"
+      }
+    }
   }
 
   # Allow IPs access in IP whitelist

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -179,7 +179,7 @@ resource "aws_wafv2_ip_set" "allowed_ips" {
   description        = "IPs that can access the DiAGRAM frontend"
   scope              = "CLOUDFRONT"
   ip_address_version = "IPV4"
-  addresses = []
+  addresses = var.secrets.allowed_ips
   # WAF must use us-east-1 region when scope is CLOUDFRONT
   provider = aws.us-east-1
 }

--- a/components/website/cloudfront.tf
+++ b/components/website/cloudfront.tf
@@ -173,7 +173,7 @@ resource "aws_cloudfront_distribution" "diagram" {
 }
 
 resource "aws_wafv2_ip_set" "allowed_ips" {
-  # Only create for dev and staging (now WAF on live)
+  # Only create for dev and staging (no WAF on live)
   count              = local.has_waf ? 1 : 0
   name               = "allowed_ips"
   description        = "IPs that can access the DiAGRAM frontend"
@@ -185,7 +185,7 @@ resource "aws_wafv2_ip_set" "allowed_ips" {
 }
 
 resource "aws_wafv2_web_acl" "cloudfront" {
-  # Only create for dev and staging (now WAF on live)
+  # Only create for dev and staging (no WAF on live)
   count = local.has_waf ? 1 : 0
   name  = "cloudfront_acl"
   scope = "CLOUDFRONT"

--- a/components/website/variables.tf
+++ b/components/website/variables.tf
@@ -48,5 +48,6 @@ variable "service" {
 locals {
   project_ns = "${var.client_id}-${var.project_id}-${terraform.workspace}"
   workspace  = terraform.workspace
+  has_waf    = contains(["dev", "stage"], terraform.workspace)
 }
 


### PR DESCRIPTION
Access to the dev and staging site should be restricted.

This PR restricts access to these sites via an IP restriction implemented in WAF.

Logic is added to only add these restrictions to the dev and staging workspaces.