### PR TITLE
Diagram shield fixes.

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.0.0"
   constraints = "6.0.0"
   hashes = [
+    "h1:I58YCevxv7mbOxABY3JAoC3eZRE/oZiRB3l9jSjshoo=",
     "h1:dbRRZ1NzH1QV/+83xT/X3MLYaZobMXt8DNwbqnJojpo=",
     "zh:16b1bb786719b7ebcddba3ab751b976ebf4006f7144afeebcb83f0c5f41f8eb9",
     "zh:1fbc08b817b9eaf45a2b72ccba59f4ea19e7fcf017be29f5a9552b623eccc5bc",

--- a/bootstrap_environments.json
+++ b/bootstrap_environments.json
@@ -117,9 +117,12 @@
                     "acm:*",
                     "ecr:*",
                     "cloudfront:*",
+                    "cloudwatch:*",
+                    "events:*",
                     "apigateway:*",
                     "logs:*",
                     "lambda:*",
+                    "shield:*",
                     "wafv2:*"
                   ],
                   "Resource": "*"
@@ -133,6 +136,8 @@
                   "Resource": [
                     {"Fn::Sub": "arn:aws:s3:::nata-dia3-${Environment}-site"},
                     {"Fn::Sub": "arn:aws:s3:::nata-dia3-${Environment}-site/*"},
+                    {"Fn::Sub": "arn:aws:s3:::${Environment}-diagram-shield-response"},
+                    {"Fn::Sub": "arn:aws:s3:::${Environment}-diagram-shield-response/*"},
                     "arn:aws:s3:::mgmt-diagram-terraform-state",
                     "arn:aws:s3:::mgmt-diagram-terraform-state/*"
                   ]
@@ -142,6 +147,7 @@
                   "Effect": "Allow",
                   "Action": [
                     "iam:AttachRolePolicy",
+                    "iam:CreatePolicy",
                     "iam:CreateRole",
                     "iam:DeleteRole",
                     "iam:DetachRolePolicy",
@@ -155,6 +161,7 @@
                     "iam:ListInstanceProfilesForRole",
                     "iam:PassRole",
                     "iam:PutRolePolicy",
+                    "iam:TagPolicy",
                     "iam:TagRole",
                     "iam:UntagRole",
                     "iam:UpdateRoleDescription",
@@ -170,6 +177,15 @@
                     },
                     {
                       "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/Role_Diagram_GitHub_OICD"
+                    },
+                    {
+                      "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/${Environment}-shield-team-response-role"
+                    },
+                    {
+                      "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/${Environment}-dr2-eventbridge-alarm-state-change-alarm-only-role"
+                    },
+                    {
+                      "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:policy/${Environment}-dr2-eventbridge-alarm-state-change-alarm-only-policy"
                     }
                   ]
                 },
@@ -177,11 +193,24 @@
                   "Sid": "",
                   "Effect": "Allow",
                   "Action": [
-                    "ssm:GetParameter"
+                    "ssm:GetParameter",
+                    "secretsmanager:CreateSecret",
+                    "secretsmanager:UpdateSecret",
+                    "secretsmanager:DescribeSecret",
+                    "secretsmanager:DeleteSecret",
+                    "secretsmanager:GetSecretValue",
+                    "secretsmanager:PutSecretValue"
+
                   ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/mgmt/account_id"
+                    },
+                    {
+                      "Fn::Sub": "arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/mgmt/slack/token"
+                    },
+                    {
+                      "Fn::Sub": "arn:aws:secretsmanager:eu-west-2:${AWS::AccountId}:secret:events!connection/*"
                     }
                   ]
                 }

--- a/root.tf
+++ b/root.tf
@@ -7,9 +7,21 @@ resource "aws_route53_zone" "hosted_zone" {
   name = local.zone_name
 }
 
+data "aws_ssm_parameter" "slack_token" {
+  name            = "/mgmt/slack/token"
+  with_decryption = true
+}
+
 module "site" {
-  source           = "./site"
-  hosted_zone_id   = aws_route53_zone.hosted_zone.id
-  hosted_zone_name = local.zone_name
-  created_by       = local.created_by
+  source              = "./site"
+  hosted_zone_id      = aws_route53_zone.hosted_zone.id
+  hosted_zone_name    = local.zone_name
+  created_by          = local.created_by
+  api_destination_arn = module.eventbridge_alarm_notifications_destination.api_destination_arn
+}
+
+module "eventbridge_alarm_notifications_destination" {
+  source                     = "git::https://github.com/nationalarchives/da-terraform-modules//eventbridge_api_destination"
+  authorisation_header_value = "Bearer ${data.aws_ssm_parameter.slack_token.value}"
+  name                       = "${terraform.workspace}-dr2-eventbridge-slack-destination"
 }

--- a/site/shield.tf
+++ b/site/shield.tf
@@ -1,9 +1,9 @@
 locals {
-  shield_topic_name = "${local.environment}-DiAGRAM-shield-notifications"
+  general_notifications_channel_id = local.environment == "live" ? "C06E20AR65V" : "C068RLCPZFE"
 }
 
 resource "aws_shield_protection" "shield_protection" {
-  for_each     = toset([aws_s3_bucket.website.arn, aws_iam_role.cloudwatch.arn])
+  for_each     = toset(["arn:aws:route53:::hostedzone/${var.hosted_zone_id}", aws_cloudfront_distribution.diagram.arn])
   name         = "DIAGRAMShieldProtection"
   resource_arn = each.value
 }
@@ -11,7 +11,7 @@ resource "aws_shield_protection" "shield_protection" {
 module "shield_response_team_role" {
   source             = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role"
   assume_role_policy = templatefile("${path.module}/templates/iam_role/shield_response_assume_role.json.tpl", {})
-  name               = "DR2ShieldResponseTeamRole${title(local.environment)}"
+  name               = "${local.environment}-shield-team-response-role"
   policy_attachments = {
     access_policy = "arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy"
   }
@@ -19,23 +19,31 @@ module "shield_response_team_role" {
 }
 
 module "shield_response_s3_bucket" {
-  source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
-  common_tags = local.common_tags
-  bucket_name = aws_s3_bucket.website.bucket
+  source            = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
+  common_tags       = local.common_tags
+  bucket_name       = "${local.environment}-diagram-shield-response"
+  create_log_bucket = false
+
 }
 
-module "encryption_key" {
-  source     = "git::https://github.com/nationalarchives/da-terraform-modules//kms"
-  key_name   = "${local.environment}-kms-DiAGRAM"
-  key_policy = "message_system_access"
-}
-
-module "notifications_topic" {
-  source      = "git::https://github.com/nationalarchives/da-terraform-modules//sns"
-  topic_name  = local.shield_topic_name
-  sns_policy  = "notifications"
-  kms_key_arn = module.encryption_key.kms_key_arn
-  tags        = {}
+module "cloudwatch_event_alarm_event_bridge_rule_alarm_only" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//eventbridge_api_destination_rule"
+  event_pattern = templatefile("${path.module}/templates/eventbridge/cloudwatch_alarm_event_pattern.json.tpl", {
+    cloudwatch_alarms = jsonencode([module.shield_cloudwatch_rules["s3_bucket"].cloudwatch_alarm_arn, module.shield_cloudwatch_rules["cloudfront"].cloudwatch_alarm_arn]),
+    state_value       = "ALARM"
+  })
+  name                = "${local.environment}-dr2-eventbridge-alarm-state-change-alarm-only"
+  api_destination_arn = var.api_destination_arn
+  api_destination_input_transformer = {
+    input_paths = {
+      "alarmName"    = "$.detail.alarmName",
+      "currentValue" = "$.detail.state.value"
+    }
+    input_template = templatefile("${path.module}/templates/eventbridge/slack_message_input_template.json.tpl", {
+      channel_id   = local.general_notifications_channel_id
+      slackMessage = ":warning: Cloudwatch alarm <alarmName> has entered state <currentValue>"
+    })
+  }
 }
 
 module "shield_cloudwatch_rules" {
@@ -47,7 +55,6 @@ module "shield_cloudwatch_rules" {
   name                = "shield-metric-${each.key}"
   metric_name         = "DDoSDetected"
   threshold           = 1
-  notification_topic  = module.notifications_topic.sns_arn
   dimensions          = { "ResourceArn" = each.value }
   statistic           = "Sum"
   namespace           = "AWS/DDoSProtection"

--- a/site/shield.tf
+++ b/site/shield.tf
@@ -29,7 +29,7 @@ module "shield_response_s3_bucket" {
 module "cloudwatch_event_alarm_event_bridge_rule_alarm_only" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//eventbridge_api_destination_rule"
   event_pattern = templatefile("${path.module}/templates/eventbridge/cloudwatch_alarm_event_pattern.json.tpl", {
-    cloudwatch_alarms = jsonencode([module.shield_cloudwatch_rules["s3_bucket"].cloudwatch_alarm_arn, module.shield_cloudwatch_rules["cloudfront"].cloudwatch_alarm_arn]),
+    cloudwatch_alarms = jsonencode([module.shield_cloudwatch_rules["route_53_zone"].cloudwatch_alarm_arn, module.shield_cloudwatch_rules["cloudfront"].cloudwatch_alarm_arn]),
     state_value       = "ALARM"
   })
   name                = "${local.environment}-dr2-eventbridge-alarm-state-change-alarm-only"
@@ -48,8 +48,8 @@ module "cloudwatch_event_alarm_event_bridge_rule_alarm_only" {
 
 module "shield_cloudwatch_rules" {
   for_each = {
-    s3_bucket  = aws_s3_bucket.website.arn,
-    cloudfront = aws_iam_role.cloudwatch.arn,
+    route_53_zone = "arn:aws:route53:::hostedzone/${var.hosted_zone_id}",
+    cloudfront    = aws_cloudfront_distribution.diagram.arn,
   }
   source              = "git::https://github.com/nationalarchives/da-terraform-modules//cloudwatch_alarms"
   name                = "shield-metric-${each.key}"

--- a/site/templates/eventbridge/cloudwatch_alarm_event_pattern.json.tpl
+++ b/site/templates/eventbridge/cloudwatch_alarm_event_pattern.json.tpl
@@ -1,0 +1,16 @@
+{
+  "source": [
+    "aws.cloudwatch"
+  ],
+  "detail-type": [
+    "CloudWatch Alarm State Change"
+  ],
+  "resources": ${cloudwatch_alarms},
+  "detail": {
+    "state": {
+      "value": [
+        "${state_value}"
+      ]
+    }
+  }
+}

--- a/site/templates/eventbridge/slack_message_input_template.json.tpl
+++ b/site/templates/eventbridge/slack_message_input_template.json.tpl
@@ -1,0 +1,4 @@
+{
+  "channel" : "${channel_id}",
+  "text": "${slackMessage}"
+}

--- a/site/variables.tf
+++ b/site/variables.tf
@@ -3,3 +3,5 @@ variable "hosted_zone_id" {}
 variable "hosted_zone_name" {}
 
 variable "created_by" {}
+
+variable "api_destination_arn" {}


### PR DESCRIPTION
There are a few bits changed here

* Add eventbridge connection for slack notification
* Add eventbridge rule for alarm notifications
* Remove encryption key and SNS topic
* Pass route53 and cloudfront arns to the shield protection resource
* Update the terraform policy to allow this
