### PR TITLE
DR2-2493 Enable Cloudfront caching.

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.0.0"
   constraints = "6.0.0"
   hashes = [
+    "h1:DhxTTyLjzmC0wRCodYOWkIGwHAYb2Fcg3zFc/3sIpvk=",
     "h1:I58YCevxv7mbOxABY3JAoC3eZRE/oZiRB3l9jSjshoo=",
     "h1:dbRRZ1NzH1QV/+83xT/X3MLYaZobMXt8DNwbqnJojpo=",
     "zh:16b1bb786719b7ebcddba3ab751b976ebf4006f7144afeebcb83f0c5f41f8eb9",

--- a/site/website_cloudfront.tf
+++ b/site/website_cloudfront.tf
@@ -24,6 +24,14 @@ resource "aws_cloudfront_origin_access_control" "website" {
   signing_protocol                  = "sigv4"
 }
 
+data "aws_cloudfront_cache_policy" "caching_optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
 # HTTP security headers
 resource "aws_cloudfront_response_headers_policy" "diagram" {
   name = "security-headers"
@@ -103,7 +111,7 @@ resource "aws_cloudfront_distribution" "diagram" {
       "HEAD",
       "GET"
     ]
-    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6" # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-caching-optimized
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
     response_headers_policy_id = aws_cloudfront_response_headers_policy.diagram.id
   }
 
@@ -127,7 +135,7 @@ resource "aws_cloudfront_distribution" "diagram" {
       "HEAD",
       "GET"
     ]
-    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-policy-caching-disabled
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
     response_headers_policy_id = aws_cloudfront_response_headers_policy.diagram.id
   }
 

--- a/site/website_cloudfront.tf
+++ b/site/website_cloudfront.tf
@@ -103,17 +103,11 @@ resource "aws_cloudfront_distribution" "diagram" {
       "HEAD",
       "GET"
     ]
-    # Forward full request and any cookies
-    forwarded_values {
-      query_string = true
-      cookies {
-        forward = "all"
-      }
-    }
+    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6" # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-caching-optimized
     response_headers_policy_id = aws_cloudfront_response_headers_policy.diagram.id
   }
 
-  # Forward requsts of /api/ to API Gateway
+  # Forward requests of /api/ to API Gateway
   ordered_cache_behavior {
     path_pattern           = "/api/*"
     target_origin_id       = "${local.project_ns}-api_gw"
@@ -133,13 +127,7 @@ resource "aws_cloudfront_distribution" "diagram" {
       "HEAD",
       "GET"
     ]
-    # Forward full request and any cookies
-    forwarded_values {
-      query_string = true
-      cookies {
-        forward = "all"
-      }
-    }
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-policy-caching-disabled
     response_headers_policy_id = aws_cloudfront_response_headers_policy.diagram.id
   }
 
@@ -155,7 +143,7 @@ resource "aws_cloudfront_distribution" "diagram" {
     origin_id                = aws_s3_bucket.website.id
   }
 
-  # Attach SSL cerification
+  # Attach SSL certification
   viewer_certificate {
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"


### PR DESCRIPTION
The UUIDs are the IDs of AWS managed cache policies. I've added a link
to the descriptions of each in a comment.
